### PR TITLE
Dev

### DIFF
--- a/ampapi.go
+++ b/ampapi.go
@@ -14,7 +14,7 @@ import (
 const (
 	Author  = "Dylan Sperrer"
 	Email   = "dylan@neuralnexus.dev"
-	Version = "1.0.8"
+	Version = "1.0.9"
 )
 
 // AMPAPI struct

--- a/apimodules/ADSModule.go
+++ b/apimodules/ADSModule.go
@@ -595,10 +595,12 @@ func (a *ADSModule) RefreshInstanceConfig(InstanceId string) ampapi.Task[ampapi.
 
 /* RefreshRemoteConfigStores - 
  * Name Description Optional
+ * param force bool  True
  * return any
  */
-func (a *ADSModule) RefreshRemoteConfigStores() any {
+func (a *ADSModule) RefreshRemoteConfigStores(force bool) any {
     var args = make(map[string]any)
+    args["force"] = force
     var res any
     json.Unmarshal(a.ApiCall("ADSModule/RefreshRemoteConfigStores", args), &res)
     return res
@@ -832,9 +834,9 @@ func (a *ADSModule) UpdateDeploymentTemplate(templateToUpdate any) ampapi.Action
  * param MemoryPolicy any  False
  * param ContainerMaxCPU any  False
  * param ContainerImage string  False
- * return ampapi.Task[ampapi.ActionResult[any]]
+ * return ampapi.ActionResult[any]
  */
-func (a *ADSModule) UpdateInstanceInfo(InstanceId string, FriendlyName string, Description string, StartOnBoot bool, Suspended bool, ExcludeFromFirewall bool, RunInContainer bool, ContainerMemory int32, MemoryPolicy any, ContainerMaxCPU any, ContainerImage string) ampapi.Task[ampapi.ActionResult[any]] {
+func (a *ADSModule) UpdateInstanceInfo(InstanceId string, FriendlyName string, Description string, StartOnBoot bool, Suspended bool, ExcludeFromFirewall bool, RunInContainer bool, ContainerMemory int32, MemoryPolicy any, ContainerMaxCPU any, ContainerImage string) ampapi.ActionResult[any] {
     var args = make(map[string]any)
     args["InstanceId"] = InstanceId
     args["FriendlyName"] = FriendlyName
@@ -847,7 +849,7 @@ func (a *ADSModule) UpdateInstanceInfo(InstanceId string, FriendlyName string, D
     args["MemoryPolicy"] = MemoryPolicy
     args["ContainerMaxCPU"] = ContainerMaxCPU
     args["ContainerImage"] = ContainerImage
-    var res ampapi.Task[ampapi.ActionResult[any]]
+    var res ampapi.ActionResult[any]
     json.Unmarshal(a.ApiCall("ADSModule/UpdateInstanceInfo", args), &res)
     return res
 }


### PR DESCRIPTION
Updated Methods in AMP v2.4.6.8:

- `ADSModule.RefreshRemoteConfigStores` has a new parameter, `force: Boolean`
- `ADSModule.UpdateInstanceInfo` now returns `ActionResult` rather than `Task<ActionResult>`

```diff
- ADSModule.RefreshRemoteConfigStores() -> Void
+ ADSModule.RefreshRemoteConfigStores(force: Boolean) -> Void

- ADSModule.UpdateInstanceInfo(InstanceId: String, FriendlyName: String, Description: String, StartOnBoot: Boolean, Suspended: Boolean, ExcludeFromFirewall: Boolean, RunInContainer: Boolean, ContainerMemory: Int32, MemoryPolicy: ContainerMemoryPolicy, ContainerMaxCPU: Single, ContainerImage: String) -> Task<ActionResult>
+ ADSModule.UpdateInstanceInfo(InstanceId: String, FriendlyName: String, Description: String, StartOnBoot: Boolean, Suspended: Boolean, ExcludeFromFirewall: Boolean, RunInContainer: Boolean, ContainerMemory: Int32, MemoryPolicy: ContainerMemoryPolicy, ContainerMaxCPU: Single, ContainerImage: String) -> ActionResult
```